### PR TITLE
Make discoverable a property

### DIFF
--- a/src/Plug.vala
+++ b/src/Plug.vala
@@ -45,12 +45,12 @@ public class Bluetooth.Plug : Switchboard.Plug {
     }
 
     public override void shown () {
-        manager.discoverable (true);
+        manager.discoverable = true;
         manager.start_discovery.begin ();
     }
 
     public override void hidden () {
-        manager.discoverable (false);
+        manager.discoverable = false;
         manager.stop_discovery.begin ();
     }
 

--- a/src/Services/Manager.vala
+++ b/src/Services/Manager.vala
@@ -105,7 +105,7 @@ public class Bluetooth.Services.ObjectManager : Object {
                         }
                     }
 
-                    var adapter_discoverable = changed.lookup_value ("Discoverable", new VariantType("b"));
+                    var adapter_discoverable = changed.lookup_value ("Discoverable", new VariantType ("b"));
                     if (adapter_discoverable != null) {
                         if (adapter.discoverable != discoverable) {
                             adapter.discoverable = discoverable;

--- a/src/Services/Manager.vala
+++ b/src/Services/Manager.vala
@@ -34,23 +34,9 @@ public class Bluetooth.Services.ObjectManager : Object {
     public signal void device_added (Bluetooth.Services.Device device);
     public signal void device_removed (Bluetooth.Services.Device device);
 
+    public bool discoverable { get; set; default = false; }
     public bool has_object { get; private set; default = false; }
     public bool retrieve_finished { get; private set; default = false; }
-
-    private bool _discoverable = false;
-    public bool discoverable {
-        get {
-            return _discoverable;
-        }
-        set {
-            lock (adapters) {
-                _discoverable = value;
-                foreach (var adapter in adapters.values) {
-                    adapter.discoverable = value;
-                }
-            }
-        }
-    }
 
     private bool is_discovering = false;
 
@@ -79,6 +65,14 @@ public class Bluetooth.Services.ObjectManager : Object {
             }
 
             retrieve_finished = true;
+        });
+
+        notify["discoverable"].connect (() => {
+            lock (adapters) {
+                foreach (var adapter in adapters.values) {
+                    adapter.discoverable = discoverable;
+                }
+            }
         });
     }
 

--- a/src/Services/Manager.vala
+++ b/src/Services/Manager.vala
@@ -37,17 +37,27 @@ public class Bluetooth.Services.ObjectManager : Object {
     public bool has_object { get; private set; default = false; }
     public bool retrieve_finished { get; private set; default = false; }
 
-    private bool is_discoverable = false;
+    private bool _discoverable = false;
+    public bool discoverable {
+        get {
+            return _discoverable;
+        }
+        set {
+            lock (adapters) {
+                _discoverable = value;
+                foreach (var adapter in adapters.values) {
+                    adapter.discoverable = value;
+                }
+            }
+        }
+    }
+
     private bool is_discovering = false;
 
     private Settings? settings = null;
     private Bluetooth.Services.DBusInterface object_interface;
     private Gee.HashMap<string, Bluetooth.Services.Adapter> adapters;
     private Gee.HashMap<string, Bluetooth.Services.Device> devices;
-
-    public ObjectManager () {
-
-    }
 
     construct {
         adapters = new Gee.HashMap<string, Bluetooth.Services.Adapter> (null, null);
@@ -98,6 +108,13 @@ public class Bluetooth.Services.ObjectManager : Object {
                             } else {
                                 adapter.stop_discovery.begin ();
                             }
+                        }
+                    }
+
+                    var adapter_discoverable = changed.lookup_value ("Discoverable", new VariantType("b"));
+                    if (adapter_discoverable != null) {
+                        if (adapter.discoverable != discoverable) {
+                            adapter.discoverable = discoverable;
                         }
                     }
                 });
@@ -191,15 +208,6 @@ public class Bluetooth.Services.ObjectManager : Object {
                 } catch (Error e) {
                     critical (e.message);
                 }
-            }
-        }
-    }
-
-    public void discoverable (bool is_discoverable) {
-        lock (adapters) {
-            this.is_discoverable = is_discoverable;
-            foreach (var adapter in adapters.values) {
-                adapter.discoverable = is_discoverable;
             }
         }
     }


### PR DESCRIPTION
Reverts a change in #20 so that we make sure to set the adapter discover-ability to what we think it should be after it times out. In other words, make sure we set discoverable while the plug is open and not discoverable while it's closed

Makes `manager.discoverable` a property instead of a method