### PR TITLE
No object manager til shown

### DIFF
--- a/src/Plug.vala
+++ b/src/Plug.vala
@@ -20,7 +20,7 @@
 
 public class Bluetooth.Plug : Switchboard.Plug {
     private MainView main_view;
-    private Services.ObjectManager manager;
+    private Services.ObjectManager?  manager = null;
 
     public Plug () {
         var settings = new Gee.TreeMap<string, string?> (null, null);
@@ -31,12 +31,15 @@ public class Bluetooth.Plug : Switchboard.Plug {
             description: _("Configure Bluetooth Settings"),
             icon: "bluetooth",
             supported_settings: settings);
-        manager = new Bluetooth.Services.ObjectManager ();
-        manager.bind_property ("has-object", this, "can-show", GLib.BindingFlags.SYNC_CREATE);
     }
 
     public override Gtk.Widget get_widget () {
         if (main_view == null) {
+            if (manager == null) {
+                manager = new Bluetooth.Services.ObjectManager ();
+                manager.bind_property ("has-object", this, "can-show", GLib.BindingFlags.SYNC_CREATE);
+            }
+
             main_view = new MainView (manager);
             main_view.quit_plug.connect (() => hidden ());
         }


### PR DESCRIPTION
This a workaround for  this issue:
https://github.com/elementary/applichttps://github.com/elementary/applications-menu/issues/83ations-menu/issues/83

A side effect of this will be on machines that have no bluetooth adapter - the plug icon will still show in the category because the absence of an adapter is not detected until the plug is opened.  One solution would be to display a suitable message in the plug when this occurs.