### PR TITLE
Auto trust after pairing

### DIFF
--- a/src/DeviceRow.vala
+++ b/src/DeviceRow.vala
@@ -177,6 +177,7 @@ public class Bluetooth.DeviceRow : Gtk.ListBoxRow {
             set_status (Status.PAIRING);
             try {
                 yield device.pair ();
+                device.trusted = true;
             } catch (Error e) {
                 set_status (Status.UNABLE_TO_CONNECT);
                 critical (e.message);


### PR DESCRIPTION
See: #57 

If I trust the device before pairing it in didn't connect in the high fidelity profile a couple of times for some reason.

Sadly enough this doesn't fix #48. 