### PR TITLE
DeviceRow: Wait until button_clicked returns to trust paired devices

### DIFF
--- a/src/DeviceRow.vala
+++ b/src/DeviceRow.vala
@@ -171,9 +171,7 @@ public class Bluetooth.DeviceRow : Gtk.ListBoxRow {
 
         connect_button.clicked.connect (() => {
             button_clicked.begin ();
-            if (device.paired) {
-                device.trusted = true;
-            }
+            device.trusted = device.paired;
         });
     }
 

--- a/src/DeviceRow.vala
+++ b/src/DeviceRow.vala
@@ -171,6 +171,9 @@ public class Bluetooth.DeviceRow : Gtk.ListBoxRow {
 
         connect_button.clicked.connect (() => {
             button_clicked.begin ();
+            if (device.paired) {
+                device.trusted = true;
+            }
         });
     }
 
@@ -179,7 +182,6 @@ public class Bluetooth.DeviceRow : Gtk.ListBoxRow {
             set_status (Status.PAIRING);
             try {
                 yield device.pair ();
-                device.trusted = true;
             } catch (Error e) {
                 set_status (Status.UNABLE_TO_CONNECT);
                 critical (e.message);

--- a/src/DeviceRow.vala
+++ b/src/DeviceRow.vala
@@ -171,6 +171,7 @@ public class Bluetooth.DeviceRow : Gtk.ListBoxRow {
 
         connect_button.clicked.connect (() => {
             button_clicked.begin ();
+            // If pairing is succesful, mark devices as trusted so they autoconnect
             device.trusted = device.paired;
         });
     }

--- a/src/DeviceRow.vala
+++ b/src/DeviceRow.vala
@@ -171,7 +171,7 @@ public class Bluetooth.DeviceRow : Gtk.ListBoxRow {
 
         connect_button.clicked.connect (() => {
             button_clicked.begin ();
-            // If pairing is succesful, mark devices as trusted so they autoconnect
+            // If pairing is successful, mark devices as trusted so they autoconnect
             device.trusted = device.paired;
         });
     }


### PR DESCRIPTION
Fixes pairing with some devices who failed to connect likely due to a race between pairing and trusting