### PR TITLE
Fix deprecations

### DIFF
--- a/src/Services/Manager.vala
+++ b/src/Services/Manager.vala
@@ -224,7 +224,7 @@ public class Bluetooth.Services.ObjectManager : Object {
         agent = new Bluetooth.Services.Agent ();
         agent.notify["ready"].connect (() => {
             if (is_registered) {
-                register_agent ();
+                register_agent.begin ();
             }
         });
 


### PR DESCRIPTION
Fixes #95

Note that this PR does not fix the `Creation method of abstract class cannot be public` error message since it should be due to Switchboard itself.
