### PR TITLE
Add a forget button to each device

### DIFF
--- a/po/es.po
+++ b/po/es.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: switchboard-plug-bluetooth\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2020-04-28 22:16+0000\n"
-"PO-Revision-Date: 2020-05-11 16:10+0000\n"
+"PO-Revision-Date: 2020-07-02 03:12+0000\n"
 "Last-Translator: Adolfo Jayme Barrientos <fitojb@ubuntu.com>\n"
 "Language-Team: Spanish <https://l10n.elementary.io/projects/switchboard/"
 "switchboard-plug-bluetooth/es/>\n"
@@ -50,8 +50,7 @@ msgstr "Buscando"
 #: src/MainView.vala:210
 #, c-format
 msgid "Now discoverable as \"%s\". Not discoverable when this page is closed"
-msgstr ""
-"Ahora detectable como \"%s\". No detectable cuando esta página está cerrada"
+msgstr "Ahora detectable como «%s». No detectable cuando se cierra esta página"
 
 #: src/MainView.vala:210
 msgid "Unknown"
@@ -59,7 +58,7 @@ msgstr "Desconocido"
 
 #: src/MainView.vala:212
 msgid "Not discoverable while Bluetooth is powered off"
-msgstr "No detectable mientras Bluetooth está apagado"
+msgstr "No detectable mientras Bluetooth esté apagado"
 
 #: src/MainView.vala:214
 msgid "Not discoverable"
@@ -108,7 +107,7 @@ msgstr ""
 
 #: src/PairDialog.vala:94 src/PairDialog.vala:104 src/DeviceRow.vala:224
 msgid "Pair"
-msgstr "Par"
+msgstr "Emparejar"
 
 #: src/PairDialog.vala:98
 #, c-format
@@ -148,7 +147,7 @@ msgstr "No pudo conectarse"
 
 #: src/DeviceRow.vala:52
 msgid "Not Connected"
-msgstr "No Conectado"
+msgstr "No conectado"
 
 #: src/DeviceRow.vala:120
 msgid "Sound Settings"
@@ -160,7 +159,7 @@ msgstr "Configuración de teclado"
 
 #: src/DeviceRow.vala:129
 msgid "Mouse & Touchpad Settings"
-msgstr "Configuración de Ratón y Touchpad"
+msgstr "Configuración de ratón y panel táctil"
 
 #: src/DeviceRow.vala:133
 msgid "Printer Settings"

--- a/src/DeviceRow.vala
+++ b/src/DeviceRow.vala
@@ -127,7 +127,30 @@ public class Bluetooth.DeviceRow : Gtk.ListBoxRow {
         add (grid);
         show_all ();
 
-        config_settings_button ();
+        switch (device.icon) {
+            case "audio-card":
+                settings_button.uri = "settings://sound";
+                settings_button.tooltip_text = _("Sound Settings");
+                break;
+            case "input-gaming":
+            case "input-keyboard":
+                settings_button.uri = "settings://input/keyboard";
+                settings_button.tooltip_text = _("Keyboard Settings");
+                break;
+            case "input-mouse":
+                settings_button.uri = "settings://input/mouse";
+                settings_button.tooltip_text = _("Mouse & Touchpad Settings");
+                break;
+            case "printer":
+                settings_button.uri = "settings://printer";
+                settings_button.tooltip_text = _("Printer Settings");
+                break;
+            default:
+                settings_button.uri = null;
+                settings_button.tooltip_text = null;
+                break;
+        }
+
         compute_status ();
         set_sensitive (adapter.powered);
 
@@ -177,33 +200,6 @@ public class Bluetooth.DeviceRow : Gtk.ListBoxRow {
             }
         });
 
-    }
-
-    private void config_settings_button () {
-
-        switch (device.icon) {
-            case "audio-card":
-                settings_button.uri = "settings://sound";
-                settings_button.tooltip_text = _("Sound Settings");
-                break;
-            case "input-gaming":
-            case "input-keyboard":
-                settings_button.uri = "settings://input/keyboard";
-                settings_button.tooltip_text = _("Keyboard Settings");
-                break;
-            case "input-mouse":
-                settings_button.uri = "settings://input/mouse";
-                settings_button.tooltip_text = _("Mouse & Touchpad Settings");
-                break;
-            case "printer":
-                settings_button.uri = "settings://printer";
-                settings_button.tooltip_text = _("Printer Settings");
-                break;
-            default:
-                settings_button.uri = null;
-                settings_button.tooltip_text = null;
-                break;
-        }
     }
 
     private async void button_clicked () {

--- a/src/DeviceRow.vala
+++ b/src/DeviceRow.vala
@@ -100,21 +100,13 @@ public class Bluetooth.DeviceRow : Gtk.ListBoxRow {
         settings_button.no_show_all = true;
         settings_button.visible = false;
 
-        forget_button = new Gtk.Button ();
-        forget_button.image = new Gtk.Image.from_icon_name ("edit-delete-symbolic", Gtk.IconSize.MENU);
+        forget_button = new Gtk.Button.from_icon_name ("edit-delete-symbolic", Gtk.IconSize.MENU) {
+            margin_end = 3,
+            no_show_all = true,
+            tooltip_text = _("Forget this device"),
+            visible = false
+        };
         forget_button.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
-        forget_button.tooltip_text = _("Forget this device");
-        forget_button.margin_end = 3;
-        forget_button.show_all ();
-        forget_button.no_show_all = true;
-        forget_button.visible = false;
-        forget_button.button_release_event.connect (() => {
-                try {
-                    adapter.remove_device (new ObjectPath (((DBusProxy) device).g_object_path));
-                } catch (Error e) {
-                    debug ("Removing bluetooth device failed: %s", e.message);
-                }
-            });
 
         connect_button = new Gtk.Button ();
         connect_button.valign = Gtk.Align.CENTER;
@@ -176,6 +168,15 @@ public class Bluetooth.DeviceRow : Gtk.ListBoxRow {
             // If pairing is successful, mark devices as trusted so they autoconnect
             device.trusted = device.paired;
         });
+
+        forget_button.button_release_event.connect (() => {
+            try {
+                adapter.remove_device (new ObjectPath (((DBusProxy) device).g_object_path));
+            } catch (Error e) {
+                debug ("Forget bluetooth device failed: %s", e.message);
+            }
+        });
+
     }
 
     private void config_settings_button () {

--- a/src/DeviceRow.vala
+++ b/src/DeviceRow.vala
@@ -57,8 +57,7 @@ public class Bluetooth.DeviceRow : Gtk.ListBoxRow {
     }
 
     private Gtk.Button connect_button;
-    private Gtk.Image forget_button_image;
-    private Gtk.EventBox forget_button;
+    private Gtk.Button forget_button;
     private Gtk.Image state;
     private Gtk.Label state_label;
     private Gtk.LinkButton settings_button;
@@ -101,9 +100,9 @@ public class Bluetooth.DeviceRow : Gtk.ListBoxRow {
         settings_button.no_show_all = true;
         settings_button.visible = false;
 
-        forget_button_image = new Gtk.Image.from_icon_name ("edit-delete-symbolic", Gtk.IconSize.MENU);
-        forget_button = new Gtk.EventBox ();
-        forget_button.add (forget_button_image);
+        forget_button = new Gtk.Button ();
+        forget_button.image = new Gtk.Image.from_icon_name ("edit-delete-symbolic", Gtk.IconSize.MENU);
+        forget_button.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
         forget_button.tooltip_text = _("Forget this device");
         forget_button.margin_end = 3;
         forget_button.show_all ();

--- a/src/DeviceRow.vala
+++ b/src/DeviceRow.vala
@@ -56,8 +56,9 @@ public class Bluetooth.DeviceRow : Gtk.ListBoxRow {
         }
     }
 
-    private Gtk.Button remove_button;
     private Gtk.Button connect_button;
+    private Gtk.Image forget_button_image;
+    private Gtk.EventBox forget_button;
     private Gtk.Image state;
     private Gtk.Label state_label;
     private Gtk.LinkButton settings_button;
@@ -100,14 +101,15 @@ public class Bluetooth.DeviceRow : Gtk.ListBoxRow {
         settings_button.no_show_all = true;
         settings_button.visible = false;
 
-        remove_button = new Gtk.Button ();
-        remove_button.valign = Gtk.Align.CENTER;
-        remove_button.tooltip_text = _("Forget selected device");
-        remove_button.label = "Forget";
-        remove_button.show_all ();
-        remove_button.no_show_all = true;
-        remove_button.get_style_context ().add_class (Gtk.STYLE_CLASS_DESTRUCTIVE_ACTION);
-        remove_button.clicked.connect (() => {
+        forget_button_image = new Gtk.Image.from_icon_name ("user-trash-symbolic", Gtk.IconSize.MENU);
+        forget_button = new Gtk.EventBox ();
+        forget_button.add (forget_button_image);
+        forget_button.tooltip_text = _("Forget this device");
+        forget_button.margin_end = 3;
+        forget_button.show_all ();
+        forget_button.no_show_all = true;
+        forget_button.visible = false;
+        forget_button.button_release_event.connect (() => {
                 try {
                     adapter.remove_device (new ObjectPath (((DBusProxy) device).g_object_path));
                 } catch (Error e) {
@@ -119,7 +121,6 @@ public class Bluetooth.DeviceRow : Gtk.ListBoxRow {
         connect_button.valign = Gtk.Align.CENTER;
 
         size_group.add_widget (connect_button);
-        size_group.add_widget (remove_button);
 
         var grid = new Gtk.Grid ();
         grid.margin = 6;
@@ -129,13 +130,13 @@ public class Bluetooth.DeviceRow : Gtk.ListBoxRow {
         grid.attach (label, 1, 0, 1, 1);
         grid.attach (state_label, 1, 1, 1, 1);
         grid.attach (settings_button, 2, 0, 1, 2);
-        grid.attach (remove_button, 3, 0, 1, 2);
+        grid.attach (forget_button, 3, 0, 1, 2);
         grid.attach (connect_button, 4, 0, 1, 2);
 
         add (grid);
         show_all ();
 
-        config_setting_button ();
+        config_settings_button ();
         compute_status ();
         set_sensitive (adapter.powered);
 
@@ -178,7 +179,7 @@ public class Bluetooth.DeviceRow : Gtk.ListBoxRow {
         });
     }
 
-    private void config_setting_button () {
+    private void config_settings_button () {
 
         switch (device.icon) {
             case "audio-card":
@@ -255,13 +256,13 @@ public class Bluetooth.DeviceRow : Gtk.ListBoxRow {
                 settings_button.visible = false;
                 state.no_show_all = true;
                 state.visible = false;
-                remove_button.visible = false;
+                forget_button.visible = false;
                 break;
             case Status.PAIRING:
                 connect_button.sensitive = false;
                 state.icon_name = "user-away";
                 settings_button.visible = false;
-                remove_button.visible = false;
+                forget_button.visible = false;
                 break;
             case Status.CONNECTED:
                 connect_button.label = _("Disconnect");
@@ -270,42 +271,43 @@ public class Bluetooth.DeviceRow : Gtk.ListBoxRow {
                 if (settings_button.uri != "") {
                     settings_button.visible = true;
                 }
-                remove_button.visible = true;
-                remove_button.sensitive = true;
+                forget_button.sensitive = true;
+                forget_button.visible = true;
                 break;
             case Status.CONNECTING:
                 connect_button.sensitive = false;
                 state.icon_name = "user-away";
                 settings_button.visible = false;
-                remove_button.visible = true;
-                remove_button.sensitive = false;
+                forget_button.sensitive = false;
+                forget_button.visible = true;
                 break;
             case Status.DISCONNECTING:
                 connect_button.sensitive = false;
                 state.icon_name = "user-away";
                 settings_button.visible = false;
-                remove_button.visible = false;
+                forget_button.sensitive = false;
+                forget_button.visible = true;
                 break;
             case Status.NOT_CONNECTED:
                 connect_button.label = _("Connect");
                 connect_button.sensitive = true;
                 state.icon_name = "user-offline";
                 settings_button.visible = false;
-                remove_button.visible = true;
-                remove_button.sensitive = true;
+                forget_button.sensitive = true;
+                forget_button.visible = true;
                 break;
             case Status.UNABLE_TO_CONNECT:
                 connect_button.sensitive = true;
                 state.icon_name = "user-busy";
                 settings_button.visible = false;
-                remove_button.visible = false;
+                forget_button.visible = false;
                 break;
             case Status.UNABLE_TO_CONNECT_PAIRED:
                 connect_button.sensitive = true;
-                state.icon_name = "user-busy";
+                state.icon_name = "user-offline";
                 settings_button.visible = false;
-                remove_button.visible = true;
-                remove_button.sensitive = true;
+                forget_button.sensitive = true;
+                forget_button.visible = true;
                 break;
         }
         status_changed ();

--- a/src/DeviceRow.vala
+++ b/src/DeviceRow.vala
@@ -101,7 +101,7 @@ public class Bluetooth.DeviceRow : Gtk.ListBoxRow {
         settings_button.no_show_all = true;
         settings_button.visible = false;
 
-        forget_button_image = new Gtk.Image.from_icon_name ("user-trash-symbolic", Gtk.IconSize.MENU);
+        forget_button_image = new Gtk.Image.from_icon_name ("edit-delete-symbolic", Gtk.IconSize.MENU);
         forget_button = new Gtk.EventBox ();
         forget_button.add (forget_button_image);
         forget_button.tooltip_text = _("Forget this device");


### PR DESCRIPTION
closes #131 . 

Add individual forget button to each paired bluetooth device.

On this PR:

- remove the forget button from the toolbar 
- add forget button to each paired element 
- create a new state to know the difference between: Paired -> not connected / unPaired -> not connected.
- a little code refactoring: I created a function to configure the uri setting button 

I decided to use an Image + EventBox to avoid the icon to be highlighted when the device row is selected, as actually occurs with the device settings (I will try to fix and send in a new PR).

![bluetooh](https://user-images.githubusercontent.com/1039615/88182643-d2feb780-cc06-11ea-8842-51bb2a5946f3.gif)

![image](https://user-images.githubusercontent.com/1039615/88182972-3daff300-cc07-11ea-9f3b-fff61abeb3b7.png)



  
