### PR TITLE
PairDialog: Rename auth types for clarity

### DIFF
--- a/src/PairDialog.vala
+++ b/src/PairDialog.vala
@@ -17,19 +17,26 @@
 
 public class PairDialog : Granite.MessageDialog {
     public enum AuthType {
-        CONFIRMATION,
-        NORMAL,
-        PASSKEY,
-        PIN
+        REQUEST_CONFIRMATION,
+        REQUEST_AUTHORIZATION,
+        DISPLAY_PASSKEY,
+        DISPLAY_PIN_CODE
     }
 
     public ObjectPath object_path { get; construct; }
     public AuthType auth_type { get; construct; }
     public string passkey { get; construct; }
 
-    public PairDialog (ObjectPath object_path, Gtk.Window? main_window) {
+    // Un-used default constructor
+    private PairDialog () {
         Object (
-            auth_type: AuthType.NORMAL,
+            buttons: Gtk.ButtonsType.CANCEL
+        );
+    }
+
+    public PairDialog.request_authorization (ObjectPath object_path, Gtk.Window? main_window) {
+        Object (
+            auth_type: AuthType.REQUEST_AUTHORIZATION,
             buttons: Gtk.ButtonsType.CANCEL,
             object_path: object_path,
             primary_text: _("Confirm Bluetooth Pairing"),
@@ -39,7 +46,7 @@ public class PairDialog : Granite.MessageDialog {
 
     public PairDialog.display_passkey (ObjectPath object_path, uint32 passkey, uint16 entered, Gtk.Window? main_window) {
         Object (
-            auth_type: AuthType.PASSKEY,
+            auth_type: AuthType.DISPLAY_PASSKEY,
             buttons: Gtk.ButtonsType.CANCEL,
             object_path: object_path,
             passkey: "%u".printf (passkey),
@@ -50,7 +57,7 @@ public class PairDialog : Granite.MessageDialog {
 
     public PairDialog.request_confirmation (ObjectPath object_path, uint32 passkey, Gtk.Window? main_window) {
         Object (
-            auth_type: AuthType.CONFIRMATION,
+            auth_type: AuthType.REQUEST_CONFIRMATION,
             buttons: Gtk.ButtonsType.CANCEL,
             object_path: object_path,
             passkey: "%u".printf (passkey),
@@ -59,9 +66,9 @@ public class PairDialog : Granite.MessageDialog {
         );
     }
 
-    public PairDialog.with_pin_code (ObjectPath object_path, string pincode, Gtk.Window? main_window) {
+    public PairDialog.display_pin_code (ObjectPath object_path, string pincode, Gtk.Window? main_window) {
         Object (
-            auth_type: AuthType.PIN,
+            auth_type: AuthType.DISPLAY_PIN_CODE,
             buttons: Gtk.ButtonsType.CANCEL,
             object_path: object_path,
             passkey: pincode,
@@ -83,21 +90,21 @@ public class PairDialog : Granite.MessageDialog {
         }
 
         switch (auth_type) {
-            case AuthType.CONFIRMATION:
+            case AuthType.REQUEST_CONFIRMATION:
                 badge_icon = new ThemedIcon ("dialog-password");
                 secondary_text = _("Make sure the code displayed on “%s” matches the one below.").printf (device_name);
                 break;
-            case AuthType.PASSKEY:
+            case AuthType.DISPLAY_PASSKEY:
                 badge_icon = new ThemedIcon ("dialog-password");
                 secondary_text = _("“%s” would like to pair with this device. Make sure the code displayed on “%s” matches the one below.").printf (device_name, device_name);
 
                 var confirm_button = add_button (_("Pair"), Gtk.ResponseType.ACCEPT);
                 confirm_button.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
-            case AuthType.PIN:
+            case AuthType.DISPLAY_PIN_CODE:
                 badge_icon = new ThemedIcon ("dialog-password");
                 secondary_text = _("Type the code displayed below on “%s”, followed by Enter.").printf (device_name);
                 break;
-            case AuthType.NORMAL:
+            case AuthType.REQUEST_AUTHORIZATION:
                 badge_icon = new ThemedIcon ("dialog-question");
                 secondary_text = _("“%s” would like to pair with this device.").printf (device_name);
 

--- a/src/Services/Agent.vala
+++ b/src/Services/Agent.vala
@@ -65,7 +65,7 @@ public class Bluetooth.Services.Agent : Object {
     }
 
     public void display_pin_code (ObjectPath device, string pincode) throws Error, BluezError {
-        var pair_dialog = new PairDialog.with_pin_code (device, pincode, main_window);
+        var pair_dialog = new PairDialog.display_pin_code (device, pincode, main_window);
         pair_dialog.present ();
     }
 
@@ -84,7 +84,7 @@ public class Bluetooth.Services.Agent : Object {
     }
 
     public void request_authorization (ObjectPath device) throws Error, BluezError {
-        var pair_dialog = new PairDialog (device, main_window);
+        var pair_dialog = new PairDialog.request_authorization (device, main_window);
         pair_dialog.present ();
     }
 


### PR DESCRIPTION
It can be hard to tell which constructor and enum value maps to which bluetooth pairing type. Like what is "normal" and are we requesting a passkey or displaying it?

No functional changes here, just renaming for clarity.