### PR TITLE
Fix wingpanel bluetooth indicator settings fight

### DIFF
--- a/src/MainView.vala
+++ b/src/MainView.vala
@@ -144,7 +144,7 @@ public class Bluetooth.MainView : Granite.SimpleSettingsPage {
         });
 
         manager.bind_property ("is-discovering", overlaybar, "visible", GLib.BindingFlags.DEFAULT);
-        manager.bind_property ("is-powered", status_switch, "active", GLib.BindingFlags.DEFAULT);
+        manager.bind_property ("is-powered", status_switch, "active", GLib.BindingFlags.BIDIRECTIONAL | GLib.BindingFlags.SYNC_CREATE);
 
         show_all ();
     }

--- a/src/Services/Manager.vala
+++ b/src/Services/Manager.vala
@@ -42,16 +42,11 @@ public class Bluetooth.Services.ObjectManager : Object {
 
     private bool is_registered = false;
 
-    private Settings? settings = null;
     private GLib.DBusObjectManagerClient object_manager;
     private Bluetooth.Services.AgentManager agent_manager;
     private Bluetooth.Services.Agent agent;
 
     construct {
-        var settings_schema = SettingsSchemaSource.get_default ().lookup (SCHEMA, true);
-        if (settings_schema != null) {
-            settings = new Settings (SCHEMA);
-        }
         create_manager.begin ();
 
         notify["discoverable"].connect (() => {
@@ -375,10 +370,6 @@ public class Bluetooth.Services.ObjectManager : Object {
         foreach (var adapter in adapters) {
             adapter.powered = state;
             adapter.discoverable = state;
-        }
-
-        if (settings != null) {
-            settings.set_boolean ("bluetooth-enabled", state);
         }
 
         if (!state) {

--- a/src/Services/Manager.vala
+++ b/src/Services/Manager.vala
@@ -118,17 +118,12 @@ public class Bluetooth.Services.ObjectManager : Object {
             device_added (device);
             ((DBusProxy) device).g_properties_changed.connect ((changed, invalid) => {
                 var connected = changed.lookup_value ("Connected", GLib.VariantType.BOOLEAN);
-                if (connected != null) {
-                    check_global_state ();
-                }
-
                 var paired = changed.lookup_value ("Paired", GLib.VariantType.BOOLEAN);
-                if (paired != null) {
+                if (connected != null || paired != null) {
                     check_global_state ();
                 }
             });
 
-            check_global_state ();
         } else if (iface is Bluetooth.Services.Adapter) {
             unowned Bluetooth.Services.Adapter adapter = (Bluetooth.Services.Adapter) iface;
             has_object = true;
@@ -136,9 +131,6 @@ public class Bluetooth.Services.ObjectManager : Object {
             adapter_added (adapter);
             ((DBusProxy) adapter).g_properties_changed.connect ((changed, invalid) => {
                 var powered = changed.lookup_value ("Powered", GLib.VariantType.BOOLEAN);
-                if (powered != null) {
-                    check_global_state ();
-                }
 
                 var discovering = changed.lookup_value ("Discovering", GLib.VariantType.BOOLEAN);
                 if (discovering != null) {
@@ -149,10 +141,14 @@ public class Bluetooth.Services.ObjectManager : Object {
                 if (adapter_discoverable != null) {
                     check_discoverable ();
                 }
-            });
 
-            check_global_state ();
+                if (powered != null) {
+                    check_global_state ();
+                }
+            });
         }
+
+        check_global_state ();
     }
 
     private void on_interface_removed (GLib.DBusObject object, GLib.DBusInterface iface) {
@@ -282,26 +278,20 @@ public class Bluetooth.Services.ObjectManager : Object {
         }
     }
 
-    public void check_global_state () {
-        /* As this is called within a signal handler and emits a signal
-         * it should be in a Idle loop  else races occur */
-        Idle.add (() => {
-            var powered = get_global_state ();
-            var connected = get_connected ();
+    private void check_global_state () {
+        var powered = get_global_state ();
+        var connected = get_connected ();
 
-            /* Only signal if actually changed */
-            if (powered != is_powered || connected != is_connected) {
-                if (!powered) {
-                    discoverable = false;
-                }
-
-                is_connected = connected;
-                is_powered = powered;
+        /* Only signal if actually changed */
+        if (powered != is_powered || connected != is_connected) {
+            if (!powered) {
+                discoverable = false;
             }
 
-            return false;
-        });
-    }
+            is_connected = connected;
+            is_powered = powered;
+        }
+}
 
     public async void start_discovery () {
         var adapters = get_adapters ();


### PR DESCRIPTION
Fix #201 

This stops the wingpanel indicator overriding the plug and turning Bluetooth back on when switched off in the plug.  The plug no longer changes the wingpanel settings.  Instead it only interacts with the global state and turns the Bluetooth adaptor(s) on and off.  It is left to the wingpanel indicator to pick up the change and make any necessary changes to the UI and settings.

A related PR to the wingpanel will be pushed to completely synchronise the settings, plug and indicator, but this is not required for this PR to work.

An unneeded Idle is removed and an unnecessary public scope reduced to make the code more predicatble.

Suspend/reawaken still works as expected.