### PR TITLE
Wingpanel settings sync

### DIFF
--- a/src/MainView.vala
+++ b/src/MainView.vala
@@ -144,7 +144,8 @@ public class Bluetooth.MainView : Granite.SimpleSettingsPage {
         });
 
         manager.bind_property ("is-discovering", overlaybar, "visible", GLib.BindingFlags.DEFAULT);
-        manager.bind_property ("is-powered", status_switch, "active", GLib.BindingFlags.BIDIRECTIONAL | GLib.BindingFlags.SYNC_CREATE);
+        // Manager is powered is read-only
+        manager.bind_property ("is-powered", status_switch, "active", GLib.BindingFlags.DEFAULT);
 
         show_all ();
     }

--- a/src/Services/Manager.vala
+++ b/src/Services/Manager.vala
@@ -143,10 +143,7 @@ public class Bluetooth.Services.ObjectManager : Object {
                 }
 
                 if (powered != null) {
-                    Idle.add (() => {
-                        check_global_state ();
-                        return Source.REMOVE;
-                    });
+                    check_global_state ();
                 }
             });
         }
@@ -160,10 +157,7 @@ public class Bluetooth.Services.ObjectManager : Object {
         } else if (iface is Bluetooth.Services.Adapter) {
             adapter_removed ((Bluetooth.Services.Adapter) iface);
             has_object = !get_adapters ().is_empty;
-            Idle.add (() => {
-                check_global_state ();
-                return Source.REMOVE;
-            });
+            check_global_state ();
         }
 
     }

--- a/src/Services/Manager.vala
+++ b/src/Services/Manager.vala
@@ -114,7 +114,6 @@ public class Bluetooth.Services.ObjectManager : Object {
     private void on_interface_added (GLib.DBusObject object, GLib.DBusInterface iface) {
         if (iface is Bluetooth.Services.Device) {
             unowned Bluetooth.Services.Device device = (Bluetooth.Services.Device) iface;
-
             device_added (device);
             ((DBusProxy) device).g_properties_changed.connect ((changed, invalid) => {
                 var connected = changed.lookup_value ("Connected", GLib.VariantType.BOOLEAN);
@@ -123,11 +122,9 @@ public class Bluetooth.Services.ObjectManager : Object {
                     check_global_state ();
                 }
             });
-
         } else if (iface is Bluetooth.Services.Adapter) {
             unowned Bluetooth.Services.Adapter adapter = (Bluetooth.Services.Adapter) iface;
             has_object = true;
-
             adapter_added (adapter);
             ((DBusProxy) adapter).g_properties_changed.connect ((changed, invalid) => {
                 var powered = changed.lookup_value ("Powered", GLib.VariantType.BOOLEAN);
@@ -159,7 +156,6 @@ public class Bluetooth.Services.ObjectManager : Object {
             has_object = !get_adapters ().is_empty;
             check_global_state ();
         }
-
     }
 
     public void check_discovering () {
@@ -293,7 +289,7 @@ public class Bluetooth.Services.ObjectManager : Object {
             is_connected = connected;
             is_powered = powered;
         }
-}
+    }
 
     public async void start_discovery () {
         var adapters = get_adapters ();

--- a/src/Services/Manager.vala
+++ b/src/Services/Manager.vala
@@ -143,7 +143,10 @@ public class Bluetooth.Services.ObjectManager : Object {
                 }
 
                 if (powered != null) {
-                    check_global_state ();
+                    Idle.add (() => {
+                        check_global_state ();
+                        return Source.REMOVE;
+                    });
                 }
             });
         }
@@ -157,7 +160,12 @@ public class Bluetooth.Services.ObjectManager : Object {
         } else if (iface is Bluetooth.Services.Adapter) {
             adapter_removed ((Bluetooth.Services.Adapter) iface);
             has_object = !get_adapters ().is_empty;
+            Idle.add (() => {
+                check_global_state ();
+                return Source.REMOVE;
+            });
         }
+
     }
 
     public void check_discovering () {


### PR DESCRIPTION
Allows the plug to continue to react to power on/off by wingpanel indicator after merging https://github.com/elementary/wingpanel-indicator-bluetooth/pull/195 to work properly.