### PR TITLE
DeviceRow: add missing audio-headphones

### DIFF
--- a/data/bluetooth.metainfo.xml.in
+++ b/data/bluetooth.metainfo.xml.in
@@ -35,6 +35,7 @@
       <description>
         <p>Minor updates</p>
         <ul>
+          <li>Fix missing link to audio settings for some headphones</li>
           <li>Updated translations</li>
         </ul>
       </description>

--- a/src/DeviceRow.vala
+++ b/src/DeviceRow.vala
@@ -162,6 +162,7 @@ public class Bluetooth.DeviceRow : Gtk.ListBoxRow {
 
         switch (device.icon) {
             case "audio-card":
+            case "audio-headphones":
             case "audio-headset":
                 settings_button.uri = "settings://sound";
                 settings_button.tooltip_text = _("Sound Settings");


### PR DESCRIPTION
Fixes missing link for Airpods Pro and probably other headphones