### PR TITLE
DeviceRow: Replace deprecated settings URI

### DIFF
--- a/src/DeviceRow.vala
+++ b/src/DeviceRow.vala
@@ -173,7 +173,7 @@ public class Bluetooth.DeviceRow : Gtk.ListBoxRow {
                 settings_button.tooltip_text = _("Keyboard Settings");
                 break;
             case "input-mouse":
-                settings_button.uri = "settings://input/mouse";
+                settings_button.uri = "settings://input/pointer/mouse";
                 settings_button.tooltip_text = _("Mouse & Touchpad Settings");
                 break;
             case "printer":


### PR DESCRIPTION
This is marked as deprecated in [Mouse plug](https://github.com/elementary/switchboard-plug-mouse-touchpad/blob/188a8d8137a6cbd6ce5568fe7e2bb808afd63bdf/src/Plug.vala#L46-L48)