### PR TITLE
DeviceRow: use emblem icons for status

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 You'll need the following dependencies:
 
 * libadwaita-1-dev >=1.4.0
-* libgranite-7-dev
+* libgranite-7-dev >=7.4.0
 * libgtk-4-dev
 * libswitchboard-3-dev
 * meson

--- a/src/DeviceRow.vala
+++ b/src/DeviceRow.vala
@@ -75,7 +75,7 @@ public class Bluetooth.DeviceRow : Gtk.ListBoxRow {
             pixel_size = 32
         };
 
-        state = new Gtk.Image.from_icon_name ("user-offline");
+        state = new Gtk.Image.from_icon_name ("emblem-disabled");
         state.halign = Gtk.Align.END;
         state.valign = Gtk.Align.END;
 
@@ -290,14 +290,14 @@ public class Bluetooth.DeviceRow : Gtk.ListBoxRow {
                 break;
             case Status.PAIRING:
                 connect_button.sensitive = false;
-                state.icon_name = "user-away";
+                state.icon_name = "emblem-mixed";
                 settings_button.visible = false;
                 forget_button.visible = false;
                 break;
             case Status.CONNECTED:
                 connect_button.label = _("Disconnect");
                 connect_button.sensitive = true;
-                state.icon_name = "user-available";
+                state.icon_name = "emblem-enabled";
                 if (settings_button.uri != "") {
                     settings_button.visible = true;
                 }
@@ -306,14 +306,14 @@ public class Bluetooth.DeviceRow : Gtk.ListBoxRow {
                 break;
             case Status.CONNECTING:
                 connect_button.sensitive = false;
-                state.icon_name = "user-away";
+                state.icon_name = "emblem-mixed";
                 settings_button.visible = false;
                 forget_button.sensitive = false;
                 forget_button.visible = true;
                 break;
             case Status.DISCONNECTING:
                 connect_button.sensitive = false;
-                state.icon_name = "user-away";
+                state.icon_name = "emblem-mixed";
                 settings_button.visible = false;
                 forget_button.sensitive = false;
                 forget_button.visible = true;
@@ -321,20 +321,20 @@ public class Bluetooth.DeviceRow : Gtk.ListBoxRow {
             case Status.NOT_CONNECTED:
                 connect_button.label = _("Connect");
                 connect_button.sensitive = true;
-                state.icon_name = "user-offline";
+                state.icon_name = "emblem-disabled";
                 settings_button.visible = false;
                 forget_button.sensitive = true;
                 forget_button.visible = true;
                 break;
             case Status.UNABLE_TO_CONNECT:
                 connect_button.sensitive = true;
-                state.icon_name = "user-busy";
+                state.icon_name = "emblem-error";
                 settings_button.visible = false;
                 forget_button.visible = false;
                 break;
             case Status.UNABLE_TO_CONNECT_PAIRED:
                 connect_button.sensitive = true;
-                state.icon_name = "user-offline";
+                state.icon_name = "emblem-error";
                 settings_button.visible = false;
                 forget_button.sensitive = true;
                 forget_button.visible = true;

--- a/src/meson.build
+++ b/src/meson.build
@@ -21,7 +21,7 @@ shared_module(
         dependency('glib-2.0'),
         dependency('gio-2.0'),
         dependency('gobject-2.0'),
-        dependency('granite-7', version: '>=5.2.4'),
+        dependency('granite-7', version: '>=7.4.0'),
         dependency('gtk4'),
         meson.get_compiler('vala').find_library('posix'),
         switchboard_dep


### PR DESCRIPTION
Fixes chat bubble status icons. These icons are resourced into Granite these days