### PR TITLE
Manager: use GLib.Once

### DIFF
--- a/src/MainView.vala
+++ b/src/MainView.vala
@@ -23,19 +23,20 @@ public class Bluetooth.MainView : Switchboard.SettingsPage {
     private Gtk.ListBox list_box;
     private Granite.OverlayBar overlaybar;
 
-    public Services.ObjectManager manager { get; construct set; }
+    private Services.ObjectManager manager;
 
     public signal void quit_plug ();
 
-    public MainView (Services.ObjectManager manager) {
+    public MainView () {
         Object (
-            manager: manager,
             title: _("Bluetooth"),
             activatable: true
         );
     }
 
     construct {
+        manager = Bluetooth.Services.ObjectManager.get_default ();
+
         var empty_alert = new Granite.Placeholder (_("No Devices Found")) {
             description = _("Please ensure that your devices are visible and ready for pairing.")
         };

--- a/src/Plug.vala
+++ b/src/Plug.vala
@@ -36,7 +36,7 @@ public class Bluetooth.Plug : Switchboard.Plug {
             icon: "bluetooth",
             supported_settings: settings);
 
-        manager = new Bluetooth.Services.ObjectManager ();
+        manager = Bluetooth.Services.ObjectManager.get_default ();
         manager.bind_property ("has-object", this, "can-show", GLib.BindingFlags.SYNC_CREATE);
     }
 
@@ -47,7 +47,7 @@ public class Bluetooth.Plug : Switchboard.Plug {
             };
             headerbar.add_css_class (Granite.STYLE_CLASS_FLAT);
 
-            main_view = new MainView (manager) {
+            main_view = new MainView () {
                 vexpand = true
             };
 

--- a/src/Services/Manager.vala
+++ b/src/Services/Manager.vala
@@ -49,6 +49,13 @@ public class Bluetooth.Services.ObjectManager : Object {
     private Bluetooth.Services.AgentManager agent_manager;
     private Bluetooth.Services.Agent agent;
 
+    private static GLib.Once<ObjectManager> instance;
+    public static unowned ObjectManager get_default () {
+        return instance.once (() => { return new ObjectManager (); });
+    }
+
+    private ObjectManager () {}
+
     construct {
         var settings_schema = SettingsSchemaSource.get_default ().lookup (DAEMON_SCHEMA, true);
         if (settings_schema != null) {


### PR DESCRIPTION
Make ObjectManager a singleton so we don't have to pass it around.

This will come in handy later because I want to simplify row construction and I don't want every row holding a ref to the manager